### PR TITLE
Moved English-language rules to EN.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This is part of the [friendly! project](https://github.com/friendly-project), ai
 
 ## Getting started
 
-To get started with Doclint, take some time to read through the [documentation standards](Standards.md) to understand the guidelines.
+To get started with Doclint, take some time to read through the [documentation standards](Standards/README.md) for your target language to understand the guidelines.
+
+Currently, only [English (EN)](Standards/EN.md) is supported.
 
 ## Contributing
 
@@ -15,4 +17,3 @@ If you'd like to contribute to Doclint, please follow these steps:
 1. **Fork the repository**: Create a personal copy of the repository on GitHub.
 2. **Make changes**: Implement your changes in your forked repository.
 3. **Submit a pull request**: Propose your changes to the original repository by submitting a pull request.
-

--- a/Standards/EN.md
+++ b/Standards/EN.md
@@ -1,16 +1,16 @@
-# Documentation standards
+# English documentation standards
 
-[Go back](README.md)
+[Go back](../README.md)
 
 ## Introduction
 
-This document goes over the standards for writing documentation in this project. They'll help ensure that it's clear and consistent.
+This document goes over the standards for writing documentation in English. They'll help ensure that it's clear and consistent.
 
 To make referring to rules easier, they follow this format:
 
 - DOC<rule_number>: \<description>
 
-When removing a rule, the number will be reserved to prevent conflicts and moved to the [obsolete documentation standards](Obsolete/Standards.md).
+When removing a rule, the number will be reserved to prevent conflicts and moved to the [obsolete documentation standards](Obsolete/EN.md).
 
 ## Rules
 

--- a/Standards/Obsolete/EN.md
+++ b/Standards/Obsolete/EN.md
@@ -10,7 +10,7 @@ This document covers documentation standards that were removed from this project
 
 ### DOC01: Use Markdown
 
-*This rule was removed because it Doclint was originally a set of rules for writing documentation specific to the friendly! project inside GitHub. Since then it's been separated into its own repository to act as a more general-purpose tool for documentation linting. Markdown usage has instead been moved to a new Recommendations section in the [Standards](../Standards.md) document.*
+*This rule was removed because it Doclint was originally a set of rules for writing documentation specific to the friendly! project inside GitHub. Since then it's been separated into its own repository to act as a more general-purpose tool for documentation linting. Markdown usage has instead been moved to a new Recommendations section in the [Standards](../EN.md) document.*
 
 This project uses [Markdown](https://en.wikipedia.org/wiki/Markdown) to format documentation. Markdown is a lightweight markup language that makes it easy to create formatted text using a simple text editor.
 

--- a/Standards/README.md
+++ b/Standards/README.md
@@ -1,0 +1,10 @@
+# Documentation standards
+
+[Go back](../README.md)
+
+## Languages
+
+- [English (EN)](EN.md)
+  - [Obsolete](Obsolete/EN.md)
+
+More languages will be added in the future.


### PR DESCRIPTION
Fixes #3 

---

To facilitate future language additions, all current rules (English-specific) should be moved to a specific EN.md file. Future languages can be added as their language code (for example, DE.md, ES.md, CN.md).