### PR TITLE
Rename DOC to DOC-EN

### DIFF
--- a/Standards/EN.md
+++ b/Standards/EN.md
@@ -8,55 +8,55 @@ This document goes over the standards for writing documentation in English. They
 
 To make referring to rules easier, they follow this format:
 
-- DOC<rule_number>: \<description>
+- DOC-EN<rule_number>: \<description>
 
 When removing a rule, the number will be reserved to prevent conflicts and moved to the [obsolete documentation standards](Obsolete/EN.md).
 
 ## Rules
 
-### DOC02: Use simple language
+### DOC-EN02: Use simple language
 
 Use simple, straightforward language to make documentation more accessible.
 
 - Use "help" instead of "assistance".
 - "The system should have numerous pathways to accomplish the same task, without ambiguity" becomes "There should be multiple ways you can do the same task."
 
-### DOC03: Use generic terms
+### DOC-EN03: Use generic terms
 
 Use generic terms instead of specific product names to make documentation more dynamic.
 
 - Use "password manager" instead of "Bitwarden"
 - If referring to a product or service, use its name.
 
-### DOC04: Organize content with headings
+### DOC-EN04: Organize content with headings
 
 Headings are used to structure content and make it easier to read.
 
 - Use headings to break up content into sections.
 - Use a levels for headings (for example, H1 or # for the main heading, H2 or ## for main sections, H3 or ### for subsections, etc.).
 
-### DOC05: Use sentence case
+### DOC-EN05: Use sentence case
 
 Sentence case is when the first letter of the first word is capitalized, and all other words are lowercase (except for [proper nouns](https://en.wikipedia.org/wiki/Proper_noun)).
 
 - "THIS IS A HEADING" becomes "This is a heading"
 - "This Is A Subheading" becomes "This is a subheading"
 
-### DOC06: Use American English
+### DOC-EN06: Use American English
 
 American English is the most widely used form of English worldwide. To make documentation accessible to the largest audience, it's used here.
 
 - Use "color" instead of "colour"
 - Use "organize" instead of "organise"
 
-### DOC07: Use the Oxford comma
+### DOC-EN07: Use the Oxford comma
 
 The Oxford comma is the final comma in a list of 3 or more items, placed before "and" or "or".
 
 - Use "apples, oranges, and bananas" instead of "apples, oranges and bananas"
 - But "apples and bananas" is correct.
 
-### DOC08: Use contractions
+### DOC-EN08: Use contractions
 
 Contractions are used to make text more conversational and easier to read. However, avoid contractions that have double sounds, or when it makes the text vague.
 
@@ -64,7 +64,7 @@ Contractions are used to make text more conversational and easier to read. Howev
 - Use "it's" instead of "it is"
 - Don't use "this's" or "there're".
 
-### DOC09: Use inclusive language
+### DOC-EN09: Use inclusive language
 
 Inclusive language avoids terms that might be biased or insensitive. It aims to be respectful and considerate of all people.
 
@@ -72,14 +72,14 @@ Inclusive language avoids terms that might be biased or insensitive. It aims to 
 - Use "police officer" instead of "policeman"
 - Use "they" instead of "he" or "she" when gender is unknown or not needed.
 
-### DOC10: Use "might" instead of "may"
+### DOC-EN10: Use "might" instead of "may"
 
 "May" can mean permission, while "might" is for when something is possible. To make things easier, don't use "may".
 
 - "**You may** be able to complete the task" becomes "**You might** be able to complete the task".
 - "**You may not** complete the task" becomes "**You're not** allowed to complete the task".
 
-### DOC13: Avoid Latin abbreviations
+### DOC-EN13: Avoid Latin abbreviations
 
 Use full words, different formatting or reword your sentence instead of using Latin abbreviations to make documentation clearer.
 
@@ -87,14 +87,14 @@ Use full words, different formatting or reword your sentence instead of using La
 - Use a colon, comma or em-dash instead of "i.e."
 - "There's many ways you can do this, **e.g.**:" becomes "There's many ways you can do this, **for example**:"
 
-### DOC14: Avoid double sounds in pairs of words
+### DOC-EN14: Avoid double sounds in pairs of words
 
 Avoid using pairs of words that create a double sound. They can be confusing or awkward when read out loud.
 
 - Use "there's" instead of "there are"
 - "You can **see each** file that is stored on the operating system." becomes "You can **see every** file that's stored on the operating system."
 
-### DOC15: Write instructions from a user's perspective
+### DOC-EN15: Write instructions from a user's perspective
 
 When writing instructions for a task that the user can do, use a user's perspective to make them more relatable and easier to follow.
 
@@ -102,7 +102,7 @@ When writing instructions for a task that the user can do, use a user's perspect
 - Use "your" instead of "the user's."
 - Don't use "you can" when talking about a system's capabilities.
 
-### DOC16: Limit minor steps to 3
+### DOC-EN16: Limit minor steps to 3
 
 When providing minor steps or instructions, limit them to a maximum of 3. If more steps are needed, consider breaking them into separate major steps. Having more than 3 minor steps can make instructions harder to follow.
 


### PR DESCRIPTION
Resolves #8

---

This is a backwards-incompatible change. To facilitate future language additions, all English language rules should have their IDs changed from DOC<rule_number> to DOC-EN<rule_number>.

Future languages should then be added as their language code and rule number. For example, DOC-DE01, DOC-ES12, DOC-CN19.

Because this is backwards-incompatible, a notice should be sent to projects that used Doclint before this update was pushed (currently only https://github.com/friendly-project/docs).
