### PR TITLE
Expand contribution guidelines to include rule proposals, PR requirements and branch naming

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,7 +1,28 @@
 # Contributing
 
-If you'd like to contribute to Doclint, please follow these steps:
+Thanks for thinking about contributing to Doclint! We have a few guidelines to make sure contributions meet the bar for quality and consistency.
 
-1. **Fork the repository**: Create a personal copy of the repository on GitHub.
-2. **Make changes**: Implement your changes in your forked repository.
-3. **Submit a pull request**: Propose your changes to the original repository by submitting a pull request.
+## New rules
+
+If you want to propose a new rule, please create a new issue using the "Rule proposal" template. This'll help us understand your idea better, and ensure it aligns with the project's goals.
+
+When filling out the template, please provide as much detail as possible, including:
+
+- A description of the new rule in one or two sentences
+- An explanation of what issue it'll fix
+- Examples of writing before and after the rule is applied
+- If possible, some example of where this rule fixed the issue described above
+  - Good examples include techniques from the W3C, or examples from well-known style guides
+  - Bad examples include personal opinions or anecdotal evidence
+
+## Pull requests
+
+If you're ready to implement a new rule or fix an existing issue, please open a pull request. Make sure to:
+
+- Update the documentation as needed
+- Reference the issue your pull request fixes
+  - All pull requests should be linked to an issue, even if it's just a minor fix. This makes separating general discussion from development easier.
+
+Pull requests will be reviewed by the maintainers, and we might request changes or provide feedback. Please be patient, as we want to ensure all contributions meet our quality standards.
+
+**Note to maintainers:** All pull requests should have a branch name that reflects the issue type, number, and a short description. For example, `feature/123-new-rule-description` or `bug/456-fix-typo`.


### PR DESCRIPTION
Fixes https://github.com/friendly-project/doclint/issues/29

---

The [existing contribution guidelines](https://github.com/friendly-project/doclint/blob/main/.github/CONTRIBUTING.md) lack information about rule proposals, pull request (PR) requirements and branch naming.

1. New rules: Include a summarized version of the rule proposal template, explaining what's required and why, and include good/bad examples.
2. PR requirements: PRs should also update documentation as needed and reference an existing or new issue
3. Branch naming: All PRs should have a branch name that reflects the issue type, number, and a short description. For example, `feature/123-new-rule-description` or `bug/456-fix-typo`.